### PR TITLE
Added command line parameter to control SLOT_DISTANCE value

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -98,6 +98,13 @@ struct Options {
     ignore_base58: bool,
     #[structopt(long = "config", help = "config path")]
     config: Option<PathBuf>,
+    #[structopt(
+        long = "slot-distance",
+        short = "d",
+        help = "Health check slot distance",
+        default_value = "150"
+    )]
+    slot_dist: u32,
 }
 
 #[derive(Debug)]
@@ -225,6 +232,7 @@ async fn run(options: Options) -> Result<()> {
         &options.ws_url,
         options.time_to_live,
         rpc_slot.clone(),
+        options.slot_dist,
     );
 
     let config_file = options


### PR DESCRIPTION
Things to consider:
AccountUpdateManager struct potentially might have a lot of instances,
and withc current implementation every instance will eat up additional 4
bytes.
Alternative would be to create a mutable static, and initialize it once at
program startup, while this would introduce unsafe into code, it will
remove unnecessary overhead of 4 bytes.