### PR TITLE
Made backoff for websocket connection attempts infinite

### DIFF
--- a/src/pubsub.rs
+++ b/src/pubsub.rs
@@ -325,6 +325,8 @@ impl AccountUpdateManager {
             let mut backoff = backoff::ExponentialBackoff {
                 current_interval: Duration::from_millis(300),
                 initial_interval: Duration::from_millis(300),
+                max_interval: Duration::from_secs(10),
+                max_elapsed_time: None, // will never terminate
                 ..Default::default()
             };
 


### PR DESCRIPTION
Maximum interval length between backoffs is set to 10 sec

Closes #165 