### PR TITLE
Fixed failing tests due to range error

### DIFF
--- a/src/filter/tests.rs
+++ b/src/filter/tests.rs
@@ -40,19 +40,17 @@ prop_compose! {
     }
 }
 
-fn offsets(data_len: usize) -> impl Strategy<Value = usize> {
+fn offset_and_len(data_len: usize) -> impl Strategy<Value = (usize, usize)> {
     if data_len < 2 {
-        // We have to stick to 0 for short sizes, so tests won't fail with
-        // 'Uniform::new called with `low >= high`'
-        Just(0).boxed()
-    } else {
-        (0..(data_len - 1)).boxed()
+        return Just((0, 2)).boxed();
     }
+    ((0..(data_len - 1)), Just(data_len)).boxed()
 }
 
 prop_compose! {
-    fn valid_ranges(data_len: usize)(offset in offsets(data_len))
-                   (offset in Just(offset), slice_len in 1..(data_len - offset).min(128))
+    // data_len should always be greater than 1
+    fn valid_ranges(data_len: usize)((offset, len) in offset_and_len(data_len))
+                   (offset in Just(offset), slice_len in 1..(len - offset).min(128))
                    -> (usize, usize) {
         (offset, slice_len)
     }


### PR DESCRIPTION
The issue was that helper `account` method generated `AccountData`
values with `len()` ranging from 1, in case if len turned out to be 1,
then `valid_ranges` couldn't generate range, since it also tried to
build range starting from value 1 and ending with whatever is the `len()` of
`AccountData`, 1..1 in case which triggered error.

As a solution, the minimum `AccountData` length was set to 2, since
there's no logic requirements for it to start from 1.

Closes #159 