### PR TITLE
Added default slot for getProgramAccount requests

### DIFF
--- a/src/pubsub.rs
+++ b/src/pubsub.rs
@@ -910,6 +910,7 @@ impl AccountUpdateManager {
                                 key_ref.clone(),
                                 filter_groups,
                                 *commitment,
+                                slot,
                             );
 
                             // important for proper removal


### PR DESCRIPTION
It should increase the number of cache hits for getAccountInfo requests,
by reusing data saved by getProgramAccount previously