### PR TITLE
Changed the data field for rpc error response

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -838,7 +838,7 @@ pub struct RpcErrorOwned {
     code: i64,
     message: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    data: Option<Box<RawValue>>,
+    data: Option<serde_json::Value>,
 }
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/src/rpc_monitor.rs
+++ b/src/rpc_monitor.rs
@@ -97,7 +97,13 @@ impl RpcMonitor {
             .send_json(&request)
             .await
             .map_err(|err| anyhow::Error::msg(err.to_string()))?;
-        let resp = resp.json::<Flatten<Response<Resp>>>().await?;
+        let resp = match resp.json::<Flatten<Response<Resp>>>().await {
+            Ok(res) => res,
+            Err(e) => {
+                warn!(?resp, "Failed to parse JSON reponse");
+                return Err(anyhow::Error::from(e));
+            }
+        };
         match resp.inner {
             Response::Result(resp) => Ok(resp),
             Response::Error(err) => {


### PR DESCRIPTION
It was done to handle getHealth responses correctly, and avoid following
error:

> I regularry see the following message in the rpc-cache logs
```
Oct 31 11:40:46 lon2 cache-rpc[6705]: Oct 31 11:40:46.750  WARN global{version=0.1.34}: cache_rpc::rpc_monitor: error updating rpc health err=Json deserialize error: invalid type: newtype struct, expected any valid JSON value at line 1 column 121
```