### PR TITLE
Improved cache hit probability for accounts after owner sub ends

### DIFF
--- a/src/rpc/cacheable.rs
+++ b/src/rpc/cacheable.rs
@@ -137,7 +137,8 @@ impl Cacheable for GetAccountInfo {
         id: &Id<'a>,
         state: &State,
     ) -> Option<Result<CachedResponse, Error<'a>>> {
-        state.accounts.get(&self.pubkey).and_then(|data| {
+        let mut slot_update = None;
+        let result = state.accounts.get(&self.pubkey).and_then(|data| {
             let mut account = data.value().get(self.commitment());
             let owner = account.and_then(|(info, _)| info).map(|info| info.owner);
 
@@ -145,7 +146,13 @@ impl Cacheable for GetAccountInfo {
                 Some((Some(info), slot)) if slot == 0 => state
                     .program_accounts
                     .get_slot(&(info.owner, self.commitment()))
-                    .map(|slot| (Some(info), slot)),
+                    .map(|slot| {
+                        if slot > 0 {
+                            slot_update = Some(slot);
+                        }
+                        (Some(info), slot)
+                    }),
+
                 acc => acc,
             };
 
@@ -170,7 +177,15 @@ impl Cacheable for GetAccountInfo {
                 }
                 _ => None,
             }
-        })
+        });
+        // we have to update accounts map outside of closure, because
+        // its underlying Dashmap will deadlock otherwise
+        if let Some(slot) = slot_update {
+            state
+                .accounts
+                .update_account_slot(&self.pubkey, self.commitment(), slot);
+        }
+        result
     }
 
     fn put_into_cache(&self, state: &State, data: Self::ResponseData) -> bool {

--- a/src/types.rs
+++ b/src/types.rs
@@ -302,6 +302,12 @@ impl AccountState {
         }
     }
 
+    fn update_slot(&mut self, commitment: Commitment, slot: Slot) {
+        if let Some(Some(acc)) = self.data.get_mut(commitment.as_idx()) {
+            acc.slot = slot;
+        }
+    }
+
     pub fn get_ref(&self, commitment: Commitment) -> Option<Arc<Pubkey>> {
         self.data[commitment.as_idx()]
             .as_ref()
@@ -370,6 +376,12 @@ impl AccountsDb {
 
     pub fn get(&self, key: &Pubkey) -> Option<Ref<'_, Pubkey, AccountState>> {
         self.map.get(key)
+    }
+
+    pub fn update_account_slot(&self, pubkey: &Pubkey, commitment: Commitment, slot: Slot) {
+        if let Some(mut entry) = self.map.get_mut(pubkey) {
+            entry.update_slot(commitment, slot);
+        }
     }
 
     pub fn insert(&self, key: Pubkey, data: AccountContext, commitment: Commitment) -> Arc<Pubkey> {


### PR DESCRIPTION
In case if websocket updates for account entry are managed by its owner subscription, then if account doesn't have slot info, and no updates are sent via websocket during program's ttl, then after program subscription is terminated, account still won't have any slot info, which will result in cache miss, after the owner program is purged. 

This PR adds extra step to account retrieval from cache, which will update account slot, in case if doesn't have one, and if owner program has its slot info present. Which should improve the probability of cache hits for accounts after owner is purged from cache.  

Solves https://zubr-exchange.atlassian.net/browse/SOL-94