### PR TITLE
Support getIdentity method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "cache-rpc"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "actix",
  "actix-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "cache-rpc"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "actix",
  "actix-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cache-rpc"
-version = "0.2.9"
+version = "0.2.10"
 authors = ["Alexander Polakov <a.polakov@iconic.vc>"]
 edition = "2018"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The server supports a number of configuration options, which are the following:
   default is 60 seconds. Timeouts for `getAccountinfo` and `getProgramAccounts`
   requests are configured separately via configuration file.
 - `--rules` — path to firewall rules written in lua
+- `--identity` — optional identity key for cacherpc service, should be base58 encoded public key 
 - `--control-socket-path` — path to socket file, e.g. /run/cacherpc.sock
 
 #### Configuration file

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -235,16 +235,9 @@ impl Config {
     }
 }
 
-fn parse_identity(value: &str) -> Result<String, anyhow::Error> {
-    if let Ok(s) = std::fs::read_to_string(value) {
-        let vec: Vec<u8> = serde_json::from_str(&s)?;
-        if vec.len() != 64 {
-            return Err(anyhow::anyhow!("invalid keypair file provided"));
-        }
-        return Ok(bs58::encode(&vec[32..]).into_string());
-    }
+fn parse_identity(value: &str) -> Result<String, &'static str> {
     match bs58::decode(value).into_vec() {
         Ok(vec) if vec.len() == 32 => Ok(value.into()),
-        _ => Err(anyhow::anyhow!("invalid identity key was provided")),
+        _ => Err("invalid identity key was provided"),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,6 +174,7 @@ async fn run(options: cli::Options) -> Result<()> {
     let rpc_config = Arc::new(ArcSwap::from(Arc::new(config.rpc)));
     let timeout = options.request_timeout;
 
+    let identity = options.identity;
     HttpServer::new(move || {
         let waf = rules_path
             .as_ref()
@@ -213,6 +214,7 @@ async fn run(options: cli::Options) -> Result<()> {
             },
             waf,
             waf_watch: RefCell::new(waf_rx.clone()),
+            identity: identity.clone(),
         };
         let cors = Cors::default()
             .allow_any_origin()

--- a/src/rpc/handler.rs
+++ b/src/rpc/handler.rs
@@ -11,6 +11,7 @@ use tracing::{error, info, warn};
 
 use crate::metrics::rpc_metrics as metrics;
 use crate::rpc::request::{GetAccountInfo, GetProgramAccounts};
+use crate::rpc::response::identity_response;
 
 use super::request::{Id, Request};
 use super::response::Error;
@@ -143,6 +144,15 @@ pub async fn rpc_handler(
                     req.method,
                     arc_state.process_request::<GetProgramAccounts>(req)
                 );
+            }
+            "getIdentity" if app_state.identity.is_some() => {
+                return Ok(identity_response(
+                    req.id,
+                    app_state
+                        .identity
+                        .as_ref()
+                        .expect("no identity, shouldn't happen"),
+                ));
             }
             method => {
                 metrics().request_types(method).inc();

--- a/src/rpc/state.rs
+++ b/src/rpc/state.rs
@@ -48,6 +48,7 @@ pub struct State {
     pub lru: RefCell<LruCache<u64, LruEntry>>,
     pub worker_id: String,
     pub waf: Option<Waf>,
+    pub identity: Option<String>,
 }
 
 pub struct Waf {


### PR DESCRIPTION
Implemented special handling of `getIdentity` RPC method. If the service was started up with `--identity` option, then all `getIdentity` requests will be served by cacherpc itself, otherwise they will be forwarded on