### PR TITLE
Implemented optimized filter based caching for gPA

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -288,6 +288,7 @@ pub struct RpcMetrics {
     pub backend_requests_count: IntCounterVec,
     pub serialization_time: HistogramVec,
     pub account_data_len: HistogramVec,
+    pub self_initiated_gpa: IntCounter,
 }
 
 impl RpcMetrics {
@@ -540,6 +541,11 @@ pub fn rpc_metrics() -> &'static RpcMetrics {
                 52_428_800.,
                 104_857_600.,
             ]
+        )
+        .unwrap(),
+        self_initiated_gpa: register_int_counter!(
+            "self_initiated_gpa",
+            "Number of getProgramAccounts requests, which were initiated by cacherpc itself"
         )
         .unwrap(),
     });

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -28,6 +28,7 @@ pub(super) struct GetAccountInfo {
     pub(super) config_hash: u64,
 }
 
+#[derive(Clone)]
 pub(super) struct GetProgramAccounts {
     pub(super) pubkey: Pubkey,
     pub(super) config: ProgramAccountsConfig,
@@ -65,7 +66,7 @@ pub(super) struct AccountInfoConfig {
     pub(super) data_slice: Option<Slice>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub(super) struct ProgramAccountsConfig {
     #[serde(default = "Encoding::default")]
     pub(super) encoding: Encoding,
@@ -78,7 +79,7 @@ pub(super) struct ProgramAccountsConfig {
     pub(super) with_context: Option<bool>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(from = "SmallVec<[Filter; 3]>")]
 pub(super) enum MaybeFilters {
     Valid(Filters),


### PR DESCRIPTION
By introducing the concept of filter supersets and intersections, similar
to ones found in set theory, we are now able to serve requests from
cache for related filters, even if we don't have cache entry for the given filter

Filter superset. One filter is called a superset of the other, if it
selects the data which includes the data selected by other filter.

Ex: Filter(dataSize: X, [memcmp: A]) is the superset of
Filter(dataSize: X, [memcmp: A, memcmp: B]) as it's less restrictive and
will include more data

Filter intersection. An intersection of two filters is another different filter,
which is superset of two previous filters. In different words, it's the
filter which less restrictive than the ones that produced it. Only
filters with 2 memcmp can produce a valid intersection, because otherwise it
wouldn't make sense, and might produce a filter which is superset of all
filters (i.e. empty filter).

Ex: an intersection of Filter(dataSize: X, [memcmp: A, memcmp: B]) and
Filter(dataSize: X, [memcmp: A, memcmp: C]) is Filter(dataSize: X, [memcmp: A]),
which is a superset of filters, that produced it

Cacher will always check for the supersets if no entry is found for the
given filter, and will apply the filter to superset before serving it to
client. If no superset can be found, then it will try to find an
intersection. If found a separate async request will be made to
validator, to fetch accounts for the given intersection filter
(superset), which should prevent future cache misses for similar filters