### PR TITLE
Implemented support for additional ws-reconnection command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -137,9 +137,18 @@ pub enum LogFormat {
 
 #[derive(Debug, StructOpt)]
 pub enum Command {
-    Subscriptions { state: SubscriptionsState },
+    Subscriptions {
+        state: SubscriptionsState,
+    },
     ConfigReload,
     WafReload,
+    ForceReconnect {
+        subcmd: ForceReconnectSubCmd,
+        #[structopt(required_if("subcmd", "init"))]
+        delay: Option<u64>,
+        #[structopt(required_if("subcmd", "init"))]
+        interval: Option<u64>,
+    },
 }
 
 impl Command {
@@ -152,6 +161,7 @@ impl Command {
                 SubscriptionsState::Off => "subscriptions/off",
                 SubscriptionsState::Status => "subscriptions/status",
             },
+            Self::ForceReconnect { .. } => "force/reconnect",
         }
     }
 }
@@ -175,6 +185,30 @@ impl std::str::FromStr for LogFormat {
             "plain" => Ok(LogFormat::Plain),
             "json" => Ok(LogFormat::Json),
             _ => Err(LogFormatParseError),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ForceReconnectSubCmd {
+    Init,
+    Status,
+    Abort,
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("must be one of: \"init\", \"status\", \"abort\"")]
+pub struct ForceReconnectSubCmdError;
+
+impl std::str::FromStr for ForceReconnectSubCmd {
+    type Err = ForceReconnectSubCmdError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "init" => Ok(ForceReconnectSubCmd::Init),
+            "status" => Ok(ForceReconnectSubCmd::Status),
+            "abort" => Ok(ForceReconnectSubCmd::Abort),
+            _ => Err(ForceReconnectSubCmdError),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,7 +119,7 @@ async fn run(options: cli::Options) -> Result<()> {
     info!(?config, "config");
 
     let subscriptions_allowed = Arc::new(AtomicBool::new(true));
-    let pubsub = PubSubManager::init(
+    let (pubsub, pubsub_actor) = PubSubManager::init(
         options.websocket_connections,
         accounts.clone(),
         program_accounts.clone(),
@@ -167,6 +167,7 @@ async fn run(options: cli::Options) -> Result<()> {
         rpc_config_sender,
         options.control_socket_path,
         waf_tx,
+        pubsub_actor,
     );
 
     actix::spawn(run_control_interface(control_state));

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -78,6 +78,8 @@ pub struct PubSubMetrics {
     pub pubsub_account_slot: IntGaugeVec,
     pub websocket_reconnects: IntCounterVec,
     pub subscriptions_skipped: IntCounter,
+    pub forced_reconnections_remaining: IntGauge,
+    pub forced_reconnections_finished: IntGauge,
 }
 
 pub fn pubsub_metrics() -> &'static PubSubMetrics {
@@ -250,6 +252,16 @@ pub fn pubsub_metrics() -> &'static PubSubMetrics {
         subscriptions_skipped: register_int_counter!(
             "subscriptions_skipped", 
             "Number of account subscriptions skipped, due to presence of owner-program subscription"
+        )
+        .unwrap(),
+        forced_reconnections_remaining: register_int_gauge!(
+            "forced_reconnections_remaining",
+            "Number of forced WS reconnection, that hasn't been performed yet"
+        )
+        .unwrap(),
+        forced_reconnections_finished: register_int_gauge!(
+            "forced_reconnections_finished",
+            "Number of forced WS reconnection, that has been already performed"
         )
         .unwrap(),
     });

--- a/src/pubsub/manager.rs
+++ b/src/pubsub/manager.rs
@@ -1,12 +1,19 @@
-use std::sync::{
-    atomic::{AtomicBool, AtomicU64, Ordering},
-    Arc,
-};
+use std::iter::repeat;
 use std::time::Duration;
+use std::{
+    collections::VecDeque,
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc,
+    },
+};
 
-use actix::{Actor, Addr, Context, Message};
+use actix::{Actor, Addr, AsyncContext, Context, Handler, Message, SpawnHandle};
 use futures_util::future::join;
+use serde::{Deserialize, Serialize};
+use tracing::warn;
 
+use crate::metrics::pubsub_metrics as metrics;
 use crate::{
     filter::Filters,
     types::{AccountsDb, Commitment, ProgramAccountsDb, Pubkey},
@@ -18,6 +25,9 @@ use super::worker::{autocmd::AccountCommand, AccountUpdateManager};
 #[derive(Clone)]
 pub struct PubSubManager {
     workers: Vec<(actix::Addr<AccountUpdateManager>, Arc<AtomicBool>)>,
+    /// indicates whether ws reconnections is running, and
+    /// contains the spawn handles to cancel those reconnections
+    reconnections: VecDeque<(Addr<AccountUpdateManager>, SpawnHandle)>,
     subscriptions_allowed: Arc<AtomicBool>,
 }
 
@@ -31,6 +41,18 @@ pub struct WorkerConfig {
 #[rtype(result = "()")]
 pub struct InitManager(pub Addr<PubSubManager>);
 
+#[derive(Deserialize, Debug, Serialize, Message)]
+#[rtype(result = "String")]
+pub(crate) enum WsReconnectInstruction {
+    Init { delay: u64, interval: u64 },
+    Status,
+    Abort,
+}
+
+#[derive(Message)]
+#[rtype(result = "()")]
+pub struct ForceReconnect;
+
 impl PubSubManager {
     pub fn init(
         connections: u32,
@@ -39,7 +61,7 @@ impl PubSubManager {
         rpc_slot: Arc<AtomicU64>,
         worker_config: WorkerConfig,
         subscriptions_allowed: Arc<AtomicBool>,
-    ) -> Self {
+    ) -> (Self, Addr<Self>) {
         let mut workers = Vec::new();
         let config = Arc::new(worker_config);
         for id in 0..connections {
@@ -54,9 +76,11 @@ impl PubSubManager {
             );
             workers.push((addr, connected))
         }
+        let reconnections = VecDeque::with_capacity(workers.len());
         let manager = PubSubManager {
             workers,
             subscriptions_allowed,
+            reconnections,
         };
         let actor = manager.clone().start();
         // make sure all the workers, have an address of pubsub manager
@@ -64,7 +88,7 @@ impl PubSubManager {
             w.do_send(InitManager(Addr::clone(&actor)));
         }
 
-        manager
+        (manager, actor)
     }
 
     fn get_idx_by_key(&self, key: (Pubkey, Commitment)) -> usize {
@@ -146,8 +170,86 @@ impl PubSubManager {
         let addr = self.get_addr_by_key((key, commitment));
         addr.do_send(AccountCommand::Unsubscribe(key, commitment))
     }
+
+    pub fn workers_count(&self) -> usize {
+        self.workers.len()
+    }
+
+    pub fn active_connection_count(&self) -> usize {
+        self.workers
+            .iter()
+            .fold(0, |acc, w| acc + w.1.load(Ordering::Relaxed) as usize)
+    }
 }
 
 impl Actor for PubSubManager {
     type Context = Context<Self>;
+}
+
+impl Handler<WsReconnectInstruction> for PubSubManager {
+    type Result = String;
+
+    fn handle(&mut self, msg: WsReconnectInstruction, ctx: &mut Self::Context) -> Self::Result {
+        match msg {
+            WsReconnectInstruction::Init { delay, interval } => {
+                if !self.reconnections.is_empty() {
+                    return "WS reconnection is already in progress, abort or wait for it to finish".into();
+                }
+
+                metrics()
+                    .forced_reconnections_remaining
+                    .set(self.workers_count() as i64);
+                metrics().forced_reconnections_finished.set(0);
+                // construct the delays iterator, for running reconnect tasks at specific intervals
+                let interval = repeat(interval)
+                    .enumerate()
+                    .map(|(i, interval)| delay + i as u64 * interval);
+                let iter = self.workers.iter().map(|(w, _)| w).cloned().zip(interval);
+
+                for (worker, delay) in iter {
+                    let handle =
+                        ctx.run_later(Duration::from_secs(delay), |actor: &mut Self, _ctx| {
+                            if let Some((worker, _)) = actor.reconnections.pop_front() {
+                                worker.do_send(ForceReconnect);
+                                metrics().forced_reconnections_remaining.dec();
+                                metrics().forced_reconnections_finished.inc();
+                            } else {
+                                warn!("reconnections are empty, shouldn't have happened");
+                            }
+                        });
+                    self.reconnections.push_back((worker, handle));
+                }
+
+                "WS reconnections initiated".into()
+            }
+            WsReconnectInstruction::Status => {
+                if self.reconnections.is_empty() {
+                    return "No WS reconnection is in progress".into();
+                }
+                format!(
+                    "WS reconnection is running\n
+                    finished reconnections count: {}\n
+                    remaining reconnections: {}",
+                    self.workers_count() - self.reconnections.len(),
+                    self.reconnections.len(),
+                )
+            }
+            WsReconnectInstruction::Abort => {
+                if self.reconnections.is_empty() {
+                    return "No WS reconnection is running to abort".into();
+                }
+                let unfinished = self.reconnections.len();
+                while let Some((_, handle)) = self.reconnections.pop_front() {
+                    ctx.cancel_future(handle);
+                }
+                format!(
+                    "WS reconnection has been aborted\n\
+                    finished reconnections count: {}\n\
+                    unfinished reconnections: {}",
+                    self.workers_count() - unfinished,
+                    unfinished,
+                )
+            }
+        }
+    }
 }

--- a/src/pubsub/worker/ws.rs
+++ b/src/pubsub/worker/ws.rs
@@ -80,8 +80,7 @@ impl AccountUpdateManager {
                 if let Some((req, _time)) = self.inflight.remove(&id) {
                     match req {
                         InflightRequest::Sub(sub, commitment) => {
-                            warn
-                                !(self.actor_id, request_id = id, error = ?error, key = %sub.key(), commitment = ?commitment, "subscribe failed");
+                            warn!(self.actor_id, request_id = id, error = ?error, key = %sub.key(), commitment = ?commitment, "subscribe failed");
                             metrics()
                                 .subscribe_errors
                                 .with_label_values(&[&self.actor_name])
@@ -98,8 +97,8 @@ impl AccountUpdateManager {
                                 .unsubscribe_errors
                                 .with_label_values(&[&self.actor_name])
                                 .inc();
-                            // it's unclear if we're subscribed now or not, so remove subscription
-                            // *and* key to resubscribe later
+                            // it's unclear if we're subscribed now or not, so
+                            // remove subscription *and* key to resubscribe later
                             if let Some(id) = self.sub_to_id.remove(&(sub, commitment)) {
                                 self.id_to_sub.remove(&id);
                             }
@@ -407,8 +406,7 @@ impl StreamHandler<Result<awc::ws::Frame, awc::error::WsProtocolError>> for Acco
             match item {
                 Frame::Ping(data) => {
                     metrics().bytes_received.with_label_values(&[&self.actor_name]).inc_by(data.len() as u64);
-                    if let Connection
-                        ::Connected { sink, .. } = &mut self.connection {
+                    if let Connection::Connected { sink, .. } = &mut self.connection {
                         if sink.write(awc::ws::Message::Pong(data)).is_err() {
                             warn!("Websocket channel is closed!");
                         }
@@ -499,9 +497,10 @@ impl StreamHandler<Result<awc::ws::Frame, awc::error::WsProtocolError>> for Acco
         }
     }
 
-    fn finished(&mut self, ctx: &mut Context<Self>) {
+    fn finished(&mut self, _: &mut Context<Self>) {
         info!(self.actor_id, "websocket stream finished");
-        ctx.stop();
+        // no need to restart actor here, as there's a lot of other
+        // ways to detect stream termination and restart actor
     }
 }
 


### PR DESCRIPTION
The command has three subcommands:
1. init `<delay> <interval>` - will start reconnecting all active
   websocket connections after `<delay>` with `<interval>` between
   reconnections. Will not clear cache, but rather will silently
   resubscribe to all existing subscriptions on new connection
2. status - will print out current reconnection progress
3. abort - will abort running reconnection task (if any)